### PR TITLE
Windows cleanup review

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ These scripts are provided to help new users with installing OMERO.server for th
 
 Read the [OMERO System Administrator Documentation](https://www.openmicroscopy.org/site/support/omero5/sysadmins/), especially the sections on requirements and installation, before using these scripts.
 
-The Linux and OS X scripts should automatically download all required files.
+The scripts should automatically download all required files.

--- a/linux/test/test_services.sh
+++ b/linux/test/test_services.sh
@@ -77,3 +77,5 @@ fi
 # stop and cleanup
 docker stop $CNAME
 docker rm $CNAME
+
+# Sadly, no test for OS X here.

--- a/linux/test/test_services.sh
+++ b/linux/test/test_services.sh
@@ -77,5 +77,3 @@ fi
 # stop and cleanup
 docker stop $CNAME
 docker rm $CNAME
-
-# Sadly, no test for Windows or OS X here.


### PR DESCRIPTION
Additional changes for #111.

The change to `readme.md` is due to the fact that the statement applies to all scripts now that the windows ones are gone, so there's no need to specify "Linux and OS X".
